### PR TITLE
white-space issue for first word of a sentence in the section of experience.

### DIFF
--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
     ['heading-default', 'font-normal text-size-[36px] leading-[41px]'],
     ['title-default', 'font-normal text-size-[14px] leading-[18px]'],
     ['subtitle-default', 'font-normal text-size-[11px] leading-[13px]'],
-    ['paragraph-default', 'font-normal text-size-[10px] leading-[13px]'],
+    ['paragraph-default', 'font-normal text-size-[10px] leading-[13px] whitespace-pre-wrap'],
     ['heading-large', 'font-normal text-size-[36px] leading-[41px]'],
     ['title-large', 'font-normal text-size-[16px] leading-[19px]'],
     ['subtitle-large', 'font-normal text-size-[14px] leading-[18px]'],


### PR DESCRIPTION
1.Fixing for that it doesn't show white-space when the first character of a sentence is white-space in the section of experience.


After:
![image](https://user-images.githubusercontent.com/64820792/183986237-c64295ff-e0bf-4fe6-8d1d-685005fcb855.png)
