### PR TITLE
Bugfix: unavailable hyperlink and unexpected padding in social media

### DIFF
--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -381,7 +381,7 @@ function showSection(isEditing, hintTemplate: string, content: string) {
             >
               <div
                 v-if="item.isShow"
-                class="px-2 "
+                class="px-2"
                 :class="getFontSizeClassName(currentState.fontSize).paragraph"
               >
                 <a

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -381,13 +381,14 @@ function showSection(isEditing, hintTemplate: string, content: string) {
             >
               <div
                 v-if="item.isShow"
-                class="px-2"
+                class="px-2 "
+                :class="getFontSizeClassName(currentState.fontSize).paragraph"
               >
                 <a
                   v-if="showSection(item.isEditing, DEFAULT_TEMPLATE.social.list[0].type, item.type)"
-                  href="item.link"
-                  :class="getFontSizeClassName(currentState.fontSize).paragraph"
                   class="text-blacks-70"
+                  :href="item.link"
+                  target="_blank"
                   v-html="showSection(item.isEditing, DEFAULT_TEMPLATE.social.list[0].type, item.type)"
                 />
               </div>

--- a/src/pages/edit/social.vue
+++ b/src/pages/edit/social.vue
@@ -168,13 +168,13 @@ function deleteItem(index: number) {
           </div>
           <div>
             <label class="note text-blacks-70">Link</label>
-            <Editor
+            <input
               v-model="item.link"
-              class-name="h-[46px]"
+              class="form-input"
               :enable="item.isShow"
               :placeholder="DEFAULT_TEMPLATE.social.list[0].link"
               :is-single-line="true"
-            />
+            >
           </div>
         </div>
       </div>


### PR DESCRIPTION
[Preview - Social Media] 
1. Resolved that hyperlinks can not be accessed.
2. Resolved that unexpected padding is shown in the preview before switching to the social media page on the sidebar.

<img width="119" alt="image" src="https://user-images.githubusercontent.com/71213611/187233524-a90b032a-c7c0-4ab9-b787-0fa5f5c0e3ba.png">
