### PR TITLE
Bugfix: sidebar duplicate not update

### DIFF
--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -54,7 +54,7 @@ function showSection(isEditing, hintTemplate: string, content: string) {
     >
       <div class="flex justify-between">
         <div
-          class="p-2 flex items-baseline gap-4 not-break-out"
+          class="p-2 flex items-baseline flex-wrap gap-4 not-break-out"
           :class="currentState.layout === 'layout-left' ? `ml-[25%] ${getEditingStyle(about.isEditing)}` : getEditingStyle(about.isEditing)"
         >
           <div

--- a/src/pages/edit/certificate.vue
+++ b/src/pages/edit/certificate.vue
@@ -9,6 +9,11 @@ const { certificate } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.certificate.list[index]))
     state.certificate.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in certificate.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': certificate.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="certificate.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="certificate.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>

--- a/src/pages/edit/education.vue
+++ b/src/pages/edit/education.vue
@@ -9,6 +9,11 @@ const { education } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.education.list[index]))
     state.education.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in education.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': education.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="education.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="education.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>

--- a/src/pages/edit/experience.vue
+++ b/src/pages/edit/experience.vue
@@ -9,6 +9,11 @@ const { experience } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.experience.list[index]))
     state.experience.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in experience.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': experience.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="experience.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="experience.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>

--- a/src/pages/edit/project.vue
+++ b/src/pages/edit/project.vue
@@ -9,6 +9,11 @@ const { project } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.project.list[index]))
     state.project.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in project.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': project.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="project.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="project.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>

--- a/src/pages/edit/skill.vue
+++ b/src/pages/edit/skill.vue
@@ -9,6 +9,11 @@ const { skill } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.skill.list[index]))
     state.skill.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in skill.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': skill.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="skill.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="skill.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>

--- a/src/pages/edit/social.vue
+++ b/src/pages/edit/social.vue
@@ -9,6 +9,11 @@ const { social } = storeToRefs(user)
 
 const isEditName = ref(false)
 const nameInput = ref<HTMLInputElement | null>(null)
+const componentKey = ref(0) // force Editor component to re-render
+
+function forceRerender() {
+  componentKey.value += 1
+}
 
 function onEditNameClick() {
   isEditName.value = !isEditName.value
@@ -68,6 +73,7 @@ function duplicateItem(index: number) {
     const currentItem = JSON.parse(JSON.stringify(state.social.list[index]))
     state.social.list.splice(index, 0, currentItem)
   })
+  forceRerender()
 }
 
 function deleteItem(index: number) {
@@ -113,7 +119,7 @@ function deleteItem(index: number) {
     </p>
     <div
       v-for="(item, index) in social.list"
-      :key="index"
+      :key="componentKey + '-' + index"
       class="group"
       @focusin="() => focusIn(index)"
       @focusout="() => focusOut(index)"
@@ -128,7 +134,7 @@ function deleteItem(index: number) {
           class="invisible flex items-center gap-3"
           :class="{ 'group-hover:visible': social.isShow }"
         >
-          <button @click="toggleShowItem(index)">
+          <button v-if="social.list.length > 1" @click="toggleShowItem(index)">
             <span
               class="icon-24"
               :class="item.isShow ? 'i-custom:show' : 'i-custom:hide'"
@@ -137,7 +143,7 @@ function deleteItem(index: number) {
           <button @click="duplicateItem(index)">
             <span class="i-custom:variant icon-24" />
           </button>
-          <button @click="deleteItem(index)">
+          <button v-if="social.list.length > 1" @click="deleteItem(index)">
             <span class="i-custom:delete icon-24" />
           </button>
         </div>


### PR DESCRIPTION
Fix:
1. Sidebar Editor components do not update when clicking duplicate.
2. Set flex-wrap on name and job title.