### PR TITLE
Improve drag functionality on mobile

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,7 @@ declare module 'vue' {
     Modal: typeof import('./components/Modal.vue')['default']
     README: typeof import('./components/README.md')['default']
     Sidebar: typeof import('./components/Sidebar.vue')['default']
+    SidebarMenu: typeof import('./components/SidebarMenu.vue')['default']
     ToggleSwitch: typeof import('./components/ToggleSwitch.vue')['default']
     Toolbar: typeof import('./components/Toolbar.vue')['default']
   }

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -107,6 +107,8 @@ const { currentState } = storeToRefs(toolbar)
             group="section"
             item-key="key"
             class="h-full"
+            delay-on-touch-only
+            delay="200"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />
@@ -125,6 +127,8 @@ const { currentState } = storeToRefs(toolbar)
             group="section"
             item-key="key"
             class="h-full"
+            delay-on-touch-only
+            delay="200"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia'
 import draggable from 'vuedraggable'
 import { useUserStore } from '~/stores/user'
 import { useToolbarStore } from '~/stores/toolbar'
+import { isMobileDevice } from '~/utils'
 
 const props = defineProps<{
   id: string
@@ -108,7 +109,7 @@ const { currentState } = storeToRefs(toolbar)
             item-key="key"
             class="h-full"
             delay-on-touch-only
-            delay="200"
+            :delay="isMobileDevice() ? 200 : 0"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />
@@ -128,7 +129,7 @@ const { currentState } = storeToRefs(toolbar)
             item-key="key"
             class="h-full"
             delay-on-touch-only
-            delay="200"
+            :delay="isMobileDevice() ? 200 : 0"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
-import draggable from 'vuedraggable'
+import vuedraggable from 'vuedraggable'
 import { useUserStore } from '~/stores/user'
 import { useToolbarStore } from '~/stores/toolbar'
 import { isMobileDevice } from '~/utils'
@@ -108,7 +108,7 @@ const { currentState } = storeToRefs(toolbar)
             'w-3/4 order-1': currentState.layout === 'layout-right',
           }"
         >
-          <draggable
+          <vuedraggable
             v-if="!readOnly"
             v-model="leftList"
             group="section"
@@ -120,7 +120,7 @@ const { currentState } = storeToRefs(toolbar)
             <template #item="{element}">
               <CVPreviewSection :element="element" />
             </template>
-          </draggable>
+          </vuedraggable>
 
           <div
             v-for="(element, index) in leftList"
@@ -137,7 +137,7 @@ const { currentState } = storeToRefs(toolbar)
             'w-1/4 order-2': currentState.layout === 'layout-right',
           }"
         >
-          <draggable
+          <vuedraggable
             v-if="!readOnly"
             v-model="rightList"
             group="section"
@@ -149,7 +149,7 @@ const { currentState } = storeToRefs(toolbar)
             <template #item="{element}">
               <CVPreviewSection :element="element" />
             </template>
-          </draggable>
+          </vuedraggable>
 
           <div
             v-for="(element, index) in rightList"

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -1,16 +1,21 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import draggable from 'vuedraggable'
 import { useUserStore } from '~/stores/user'
 import { useToolbarStore } from '~/stores/toolbar'
 import { isMobileDevice } from '~/utils'
 
-const props = defineProps<{
-  id: string
-}>()
-
-const id = ref(props.id || 'cv-preview')
+const props = defineProps({
+  id: {
+    type: String,
+    default: 'cv-preview',
+  },
+  readOnly: {
+    type: Boolean,
+    default: false,
+  },
+})
 
 const user = useUserStore()
 const { splitIndex, about, summary, experience, project, skill, education, certificate, contact, social } = storeToRefs(user)
@@ -104,17 +109,26 @@ const { currentState } = storeToRefs(toolbar)
           }"
         >
           <draggable
+            v-if="!readOnly"
             v-model="leftList"
             group="section"
             item-key="key"
             class="h-full"
             delay-on-touch-only
-            :delay="isMobileDevice() ? 200 : 0"
+            :delay="isMobileDevice() ? 250 : 0"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />
             </template>
           </draggable>
+
+          <div
+            v-for="(element, index) in leftList"
+            v-else
+            :key="index"
+          >
+            <CVPreviewSection :element="element" read-only />
+          </div>
         </div>
         <div
           :class="{
@@ -124,17 +138,26 @@ const { currentState } = storeToRefs(toolbar)
           }"
         >
           <draggable
+            v-if="!readOnly"
             v-model="rightList"
             group="section"
             item-key="key"
             class="h-full"
             delay-on-touch-only
-            :delay="isMobileDevice() ? 200 : 0"
+            :delay="isMobileDevice() ? 250 : 0"
           >
             <template #item="{element}">
               <CVPreviewSection :element="element" />
             </template>
           </draggable>
+
+          <div
+            v-for="(element, index) in rightList"
+            v-else
+            :key="index"
+          >
+            <CVPreviewSection :element="element" read-only />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/CVPreview.vue
+++ b/src/components/CVPreview.vue
@@ -98,7 +98,7 @@ const { currentState } = storeToRefs(toolbar)
           'w-3/4 mr-auto': currentState.layout === 'layout-right',
         }"
       >
-        <CVPreviewSection :element="topList[0]" />
+        <CVPreviewSection :element="topList[0]" :read-only="readOnly" />
       </div>
       <div class="flex flex-wrap">
         <div
@@ -127,7 +127,7 @@ const { currentState } = storeToRefs(toolbar)
             v-else
             :key="index"
           >
-            <CVPreviewSection :element="element" read-only />
+            <CVPreviewSection :element="element" :read-only="readOnly" />
           </div>
         </div>
         <div
@@ -156,7 +156,7 @@ const { currentState } = storeToRefs(toolbar)
             v-else
             :key="index"
           >
-            <CVPreviewSection :element="element" read-only />
+            <CVPreviewSection :element="element" :read-only="readOnly" />
           </div>
         </div>
       </div>

--- a/src/components/CVPreviewSection.vue
+++ b/src/components/CVPreviewSection.vue
@@ -13,7 +13,7 @@ const props = defineProps({
   },
   readOnly: {
     type: Boolean,
-    default: true,
+    default: false,
   },
 })
 

--- a/src/components/CVPreviewSection.vue
+++ b/src/components/CVPreviewSection.vue
@@ -6,9 +6,16 @@ import { useToolbarStore } from '~/stores/toolbar'
 import { isEditorEmpty } from '~/utils'
 import { DEFAULT_TEMPLATE } from '~/constants'
 
-const props = defineProps<{
-  element: any
-}>()
+const props = defineProps({
+  element: {
+    type: Object,
+    required: true,
+  },
+  readOnly: {
+    type: Boolean,
+    default: true,
+  },
+})
 
 const user = useUserStore()
 const { about, summary, experience, project, skill, education, certificate, contact, social } = storeToRefs(user)
@@ -53,13 +60,17 @@ function isObjectEmpty(obj) {
   }
   return isEmpty
 }
+
+function redirect(path) {
+  if (!props.readOnly) router.push(path)
+}
 </script>
 
 <template>
   <div
-    @mouseover="isHover = true"
+    @mouseover="isHover = readOnly ? false : true"
     @mouseout="isHover = false"
-    @mouseup="router.push(`/edit/${element.key}`)"
+    @mouseup="redirect(`/edit/${element.key}`)"
   >
     <div
       v-if="element.key === 'about'"

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -163,7 +163,7 @@ function onMenuClick(path) {
           item-key="path"
           tag="transition-group"
           delay-on-touch-only
-          :delay="isMobileDevice() ? 200 : 0"
+          :delay="isMobileDevice() ? 250 : 0"
           @start="drag = true"
           @end="drag = false"
         >

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
-import draggable from 'vuedraggable'
+import vuedraggable from 'vuedraggable'
 import { useUserStore } from '~/stores/user'
 import { MIN_SIDEBAR_WIDTH } from '~/constants'
 import { isMobileDevice } from '~/utils'
+
+const props = defineProps({
+  draggable: {
+    type: Boolean,
+    default: true,
+  },
+})
 
 const user = useUserStore()
 const { about, summary, experience, project, skill, education, certificate, contact, social, timestamp } = storeToRefs(user)
@@ -146,7 +153,7 @@ function onMenuClick(path) {
         <span v-else class="i-custom:collapse w-6 h-6 text-blacks-40" />
       </button>
 
-      <div class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
+      <div v-if="draggable" class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
         <SidebarMenu
           v-for="element in sidebarMenus.filter((menu, index) => index === 0)"
           :key="element.path"
@@ -158,7 +165,7 @@ function onMenuClick(path) {
           :click="onMenuClick"
         />
 
-        <draggable
+        <vuedraggable
           v-model="menus"
           item-key="path"
           tag="transition-group"
@@ -177,7 +184,19 @@ function onMenuClick(path) {
               :click="onMenuClick"
             />
           </template>
-        </draggable>
+        </vuedraggable>
+      </div>
+      <div v-else class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
+        <SidebarMenu
+          v-for="element in sidebarMenus"
+          :key="element.path"
+          :path="element.path"
+          :name="element.name"
+          :icon="element.icon"
+          :show-only-icon="!isOpen"
+          :disabled="!user[element.name.toLocaleLowerCase()].isShow"
+          :click="onMenuClick"
+        />
       </div>
     </div>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -17,85 +17,114 @@ const user = useUserStore()
 const { about, summary, experience, project, skill, education, certificate, contact, social, timestamp } = storeToRefs(user)
 
 const router = useRouter()
-const sidebarMenus = [
-  {
-    name: 'About',
-    path: '/edit/about',
-    icon: 'i-custom:about',
-  },
-  {
-    name: 'Contact',
-    path: '/edit/contact',
-    // TODO: icon should use i-custom
-    icon: 'i-origin:contact',
-  },
-  {
-    name: 'Summary',
-    path: '/edit/summary',
-    icon: 'i-custom:summary',
-  },
-  {
-    name: 'Experience',
-    path: '/edit/experience',
-    icon: 'i-custom:experience',
-  },
-  {
-    name: 'Project',
-    path: '/edit/project',
-    icon: 'i-custom:project',
-  },
-  {
-    name: 'Skill',
-    path: '/edit/skill',
-    icon: 'i-custom:skill',
-  },
-  {
-    name: 'Education',
-    path: '/edit/education',
-    icon: 'i-custom:education',
-  },
-  {
-    name: 'Certificate',
-    path: '/edit/certificate',
-    icon: 'i-custom:certificate',
-  },
-  {
-    name: 'Social',
-    path: '/edit/social',
-    icon: 'i-custom:social',
-  },
-]
-const menus = computed({
+const sidebarMenus = computed(() => {
+  return [
+    {
+      id: 'about',
+      name: 'About',
+      path: '/edit/about',
+      icon: 'i-custom:about',
+      order: 0, // set to 0 if draggable is false
+      draggable: false,
+      ...getObjectProperties(about.value),
+    },
+    {
+      id: 'contact',
+      name: 'Contact',
+      path: '/edit/contact',
+      // TODO: icon should use i-custom
+      icon: 'i-origin:contact',
+      order: 1,
+      draggable: props.draggable,
+      ...getObjectProperties(contact.value),
+    },
+    {
+      id: 'summary',
+      name: 'Summary',
+      path: '/edit/summary',
+      icon: 'i-custom:summary',
+      order: 2,
+      draggable: props.draggable,
+      ...getObjectProperties(summary.value),
+    },
+    {
+      id: 'experience',
+      name: 'Experience',
+      path: '/edit/experience',
+      icon: 'i-custom:experience',
+      order: 3,
+      draggable: props.draggable,
+      ...getObjectProperties(experience.value),
+    },
+    {
+      id: 'project',
+      name: 'Project',
+      path: '/edit/project',
+      icon: 'i-custom:project',
+      order: 4,
+      draggable: props.draggable,
+      ...getObjectProperties(project.value),
+    },
+    {
+      id: 'skill',
+      name: 'Skill',
+      path: '/edit/skill',
+      icon: 'i-custom:skill',
+      order: 5,
+      draggable: props.draggable,
+      ...getObjectProperties(skill.value),
+    },
+    {
+      id: 'education',
+      name: 'Education',
+      path: '/edit/education',
+      icon: 'i-custom:education',
+      order: 6,
+      draggable: props.draggable,
+      ...getObjectProperties(education.value),
+    },
+    {
+      id: 'certificate',
+      name: 'Certificate',
+      path: '/edit/certificate',
+      icon: 'i-custom:certificate',
+      order: 7,
+      draggable: props.draggable,
+      ...getObjectProperties(certificate.value),
+    },
+    {
+      id: 'social',
+      name: 'Social Media',
+      path: '/edit/social',
+      icon: 'i-custom:social',
+      order: 8,
+      draggable: props.draggable,
+      ...getObjectProperties(social.value),
+    },
+  ].sort((a, b) => a.order - b.order)
+})
+
+const draggableMenus = computed({
   get() {
-    const content = [
-      // { key: 'about', ...about.value },
-      { key: 'summary', ...summary.value },
-      { key: 'experience', ...experience.value },
-      { key: 'project', ...project.value },
-      { key: 'skill', ...skill.value },
-      { key: 'education', ...education.value },
-      { key: 'certificate', ...certificate.value },
-      { key: 'contact', ...contact.value },
-      { key: 'social', ...social.value },
-    ].sort((a, b) => a.order - b.order)
-    return content.map(item => sidebarMenus.find(menu => menu.name.toLowerCase() === item.key))
+    return sidebarMenus.value.filter(item => item.draggable)
   },
   set(newMenus) {
     user.$patch((state) => {
       newMenus.forEach((item, index) => {
-        if (item)
-          state[item.name.toLowerCase()].order = index + 2 // order starts from 1 and skip the first one
+        if (item && item.draggable)
+          state[item.id].order = index + 1 // order starts from 1
       })
     })
   },
 })
+
 const sidebar = ref<any>(null)
 const isOpen = ref(false)
 const isSmallSidebar = ref(true)
 const drag = ref(true)
 
 const menuOpenWidth = computed(() => {
-  return isOpen.value && !isSmallSidebar.value ? 218 : 64
+  return isOpen.value && !isSmallSidebar.value ? 236 : 64
 })
 
 onMounted(() => {
@@ -107,8 +136,17 @@ onMounted(() => {
   }
 })
 
+function getObjectProperties(obj) {
+  const result = {}
+  const keys = ['order', 'isShow']
+  keys.forEach((key) => {
+    if (key in obj) result[key] = obj[key]
+  })
+  return result
+}
+
 function resize() {
-  if (sidebar.value.offsetWidth < (MIN_SIDEBAR_WIDTH + 218)) {
+  if (sidebar.value.offsetWidth < (MIN_SIDEBAR_WIDTH + 236)) {
     if (!isSmallSidebar.value)
       isOpen.value = false
 
@@ -142,7 +180,7 @@ function onMenuClick(path) {
   <div ref="sidebar" class="sidebar w-full h-full bg-white relative flex">
     <div
       class="h-full py-5 bg-white absolute top-0 left-0 z-1 sm:overflow-y-auto transition-all duration-100 flex flex-col gap-4"
-      :class="isOpen ? 'sm:w-[218px] px-5' : 'sm:w-[64px] px-1'"
+      :class="isOpen ? 'sm:w-[236px] px-5' : 'sm:w-[64px] px-1'"
     >
       <button
         :class="isOpen ? 'self-end' : 'self-center'"
@@ -153,20 +191,20 @@ function onMenuClick(path) {
         <span v-else class="i-custom:collapse w-6 h-6 text-blacks-40" />
       </button>
 
-      <div v-if="draggable" class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
+      <div class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
         <SidebarMenu
-          v-for="element in sidebarMenus.filter((menu, index) => index === 0)"
+          v-for="element in sidebarMenus.filter(item => !item.draggable)"
           :key="element.path"
           :path="element.path"
           :name="element.name"
           :icon="element.icon"
           :show-only-icon="!isOpen"
-          :disabled="!user[element.name.toLocaleLowerCase()].isShow"
+          :disabled="!user[element.id]?.isShow"
           :click="onMenuClick"
         />
 
         <vuedraggable
-          v-model="menus"
+          v-model="draggableMenus"
           item-key="path"
           tag="transition-group"
           delay-on-touch-only
@@ -180,23 +218,11 @@ function onMenuClick(path) {
               :name="element.name"
               :icon="element.icon"
               :show-only-icon="!isOpen"
-              :disabled="!user[element.name.toLocaleLowerCase()].isShow"
+              :disabled="!user[element.id]?.isShow"
               :click="onMenuClick"
             />
           </template>
         </vuedraggable>
-      </div>
-      <div v-else class="flex flex-col gap-4 overflow-y-auto disable-scrollbar">
-        <SidebarMenu
-          v-for="element in sidebarMenus"
-          :key="element.path"
-          :path="element.path"
-          :name="element.name"
-          :icon="element.icon"
-          :show-only-icon="!isOpen"
-          :disabled="!user[element.name.toLocaleLowerCase()].isShow"
-          :click="onMenuClick"
-        />
       </div>
     </div>
 

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+const props = defineProps<{
+  path: string
+  name: string
+  icon: string
+  showOnlyIcon: boolean
+  disabled: boolean
+  click: (path: string) => void
+}>()
+
+const router = useRouter()
+
+function isActivePath(targetPath: string) {
+  return router.currentRoute.value.path.indexOf(targetPath) === 0
+}
+
+function handleClick(path) {
+  props.click(path)
+}
+</script>
+
+<template>
+  <button
+    :key="path"
+    class="flex items-center px-3 py-2 hover:bg-primary-10 hover:rounded"
+    :class="isActivePath(path) && 'bg-primary-10 rounded'"
+    @click="handleClick(path)"
+  >
+    <span
+      class="w-8 h-8"
+      :class="!disabled ? `${icon} text-blacks-70` : `${icon} text-blacks-40`"
+    />
+    <span
+      class="leading ml-4"
+      :class="{
+        'hidden': showOnlyIcon,
+        'text-blacks-70': !disabled,
+        'text-blacks-40': disabled
+      }"
+    >
+      {{ name }}
+    </span>
+  </button>
+</template>

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -22,7 +22,7 @@ function handleClick(path) {
 <template>
   <button
     :key="path"
-    class="flex items-center px-3 py-2 hover:bg-primary-10 hover:rounded"
+    class="flex items-center px-3 py-2 user-select-none hover:bg-primary-10 hover:rounded"
     :class="isActivePath(path) && 'bg-primary-10 rounded'"
     @click="handleClick(path)"
   >

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -27,7 +27,7 @@ function handleClick(path) {
     @click="handleClick(path)"
   >
     <span
-      class="w-8 h-8"
+      class="w-8 h-8 flex-shrink-0"
       :class="!disabled ? `${icon} text-blacks-70` : `${icon} text-blacks-40`"
     />
     <span

--- a/src/layouts/edit.vue
+++ b/src/layouts/edit.vue
@@ -87,9 +87,11 @@ function resize() {
     isMobile.value = true
     isDesignBarOpen.value = true
     rightWidth.value = 0
-    rightSide.value.style.removeProperty('width')
-    rightSide.value.style.removeProperty('min-width')
-    leftSide.value.style.removeProperty('width')
+    if (rightSide.value) {
+      rightSide.value.style.removeProperty('width')
+      rightSide.value.style.removeProperty('min-width')
+      leftSide.value.style.removeProperty('width')
+    }
   }
   else {
     isMobile.value = false

--- a/src/layouts/edit.vue
+++ b/src/layouts/edit.vue
@@ -196,7 +196,7 @@ function getElementInnerDimensions(element) {
 </script>
 
 <template>
-  <CVPreview id="cv-preview-print" />
+  <CVPreview id="cv-preview-print" read-only />
   <main class="h-screen">
     <Header :is-edit="true" />
     <div class="w-full h-[calc(100%-137px)] border-b-1 border-blacks-20 sm:flex sm:flex-row sm:h-[calc(100%-57px)] sm:border-0 overflow-hidden">

--- a/src/layouts/edit.vue
+++ b/src/layouts/edit.vue
@@ -2,7 +2,7 @@
 import { computed, onBeforeMount, onMounted, onUnmounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useToolbarStore } from '~/stores/toolbar'
-import { getColor, setCssVariable, setStatus } from '~/utils'
+import { getColor, isMobileDevice, setCssVariable, setStatus } from '~/utils'
 import { MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH, MOBILE_BREAKPOINT, SCALES } from '~/constants'
 
 const toolbar = useToolbarStore()
@@ -292,7 +292,7 @@ function getElementInnerDimensions(element) {
         ref="rightSide"
         class="w-full h-full sm:w-[390px] sm:min-w-[390px]"
       >
-        <Sidebar />
+        <Sidebar :draggable="!isMobile || !isMobileDevice" />
       </div>
     </div>
 

--- a/src/pages/edit/download.vue
+++ b/src/pages/edit/download.vue
@@ -143,7 +143,7 @@ function back() {
           <label class="note text-blacks-70">Preview</label>
           <div id="download-preview-container">
             <div id="download-preview" class="w-[210mm] min-w-[210mm] h-[297mm] min-h-[297mm] overflow-hidden border-1 border-blacks-70 rounded-xl">
-              <CVPreview id="cv-download-preview" />
+              <CVPreview id="cv-download-preview" read-only />
             </div>
           </div>
         </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -212,6 +212,15 @@ input[type="search"]:hover::-webkit-search-cancel-button {
   counter-reset: count !important;
 }
 
+.user-select-none {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Opera and Firefox */
+}
 [data-draggable="true"] > * {
   -webkit-touch-callout: none; /* iOS Safari */
     -webkit-user-select: none; /* Safari */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -211,3 +211,13 @@ input[type="search"]:hover::-webkit-search-cancel-button {
 .cv-preview ol:first-of-type {
   counter-reset: count !important;
 }
+
+[data-draggable="true"] > * {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Old versions of Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome, Opera and Firefox */
+}


### PR DESCRIPTION
### What's included
- [x] Use props `delayOnTouchOnly` and `delay` to stimulate the long touch event.
- [x] Disable sidebar draggable on mobile.
- [x] Make cv download preview read only.

Reference: [How to use 'delay' attribute with Android devices? #926](https://github.com/SortableJS/Vue.Draggable/issues/926)