### PR TITLE
Bugfix: invalid character in download file name

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -40,7 +40,7 @@ exports.generatePdf = functions.runWith(options).https.onRequest(
       })
 
       res.setHeader('Content-Type', 'application/pdf')
-      res.setHeader('Content-Disposition', `attachment; filename=${fileName}.pdf`)
+      res.setHeader('Content-Disposition', `attachment; filename=${encodeURIComponent(fileName)}.pdf`)
       res.send(pdf)
     }
     catch (error) {


### PR DESCRIPTION
Solution: use `encodeURIComponent` to encode the download filename.