### PR TITLE
Reset redo storage for new operation

### DIFF
--- a/src/modules/pinia.ts
+++ b/src/modules/pinia.ts
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import type { UserModule } from '~/types'
 import { getStorage, hasStorage, isEditing, setStorage } from '~/utils'
 import { useUndoStore } from '~/stores/undo'
+import { useRedoStore } from '~/stores/redo'
 
 // Setup Pinia
 // https://pinia.esm.dev/
@@ -19,12 +20,22 @@ export const install: UserModule = ({ app }) => {
       if (isEditing()) {
         // exclude `undo` and `redo`
         const savedState = _.cloneDeep(_.omit(state, ['undo', 'redo']))
+        const undoStore = useUndoStore()
+        const redoStore = useRedoStore()
         setStorage(savedState)
 
-        if (['undo', 'redo'].includes(state.user.action)) { state.user.action = '' }
+        if (['undo', 'redo'].includes(state.user.action)) {
+          state.user.action = ''
+          if (redoStore.list.length === 1 && redoStore.maxRestore === 0)
+            redoStore.updateMaxRestore(undoStore.list.length + redoStore.list.length)
+        }
         else {
-          const undoStore = useUndoStore()
           undoStore.push(savedState)
+          if (redoStore.maxRestore !== 0
+              && (redoStore.list.length + undoStore.list.length) !== redoStore.maxRestore) {
+            redoStore.reset()
+            redoStore.updateMaxRestore(0)
+          }
         }
       }
     },

--- a/src/modules/pinia.ts
+++ b/src/modules/pinia.ts
@@ -31,6 +31,7 @@ export const install: UserModule = ({ app }) => {
         }
         else {
           undoStore.push(savedState)
+          // new operation is added after undo operation, then reset undo buffer
           if (redoStore.maxRestore !== 0
               && (redoStore.list.length + undoStore.list.length) !== redoStore.maxRestore) {
             redoStore.reset()

--- a/src/stores/redo.ts
+++ b/src/stores/redo.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 export const useRedoStore = defineStore('redo', {
   state: () => ({
     list: [],
-    maxRestore: 0,
+    maxRestore: 0, // the maximum number of operation for redo/undo, the value will be assigned as a constant once the first undo happened.
   }),
   getters: {
     isEmpty: state => state.list.length === 0,

--- a/src/stores/redo.ts
+++ b/src/stores/redo.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia'
 export const useRedoStore = defineStore('redo', {
   state: () => ({
     list: [],
+    maxRestore: 0,
   }),
   getters: {
     isEmpty: state => state.list.length === 0,
@@ -13,6 +14,12 @@ export const useRedoStore = defineStore('redo', {
     },
     pop() {
       return this.list.pop()
+    },
+    reset() {
+      this.list.splice(0, this.list.length)
+    },
+    updateMaxRestore(num) {
+      this.maxRestore = num
     },
   },
 })


### PR DESCRIPTION
Update the logic for redo/undo
- Redo buffer will be cleaned once any new operation (not in undo buffer) happen